### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
   function buildHTML(message) {
     if ( message.image ) {
       var html =
-        `<div class="main-contents__box">
+        `<div class="main-contents__box" data-message-id=${message.id}>
           <div class="main-contents__box__name">
             ${message.user_name}
               <div class="main-contents__box__name--created_at">
@@ -19,7 +19,7 @@ $(function() {
       return html;
     } else {
       var html =
-        `<div class="main-contents__box">
+        `<div class="main-contents__box" data-message-id=${message.id}>
           <div class="main-contents__box__name">
             ${message.user_name}
               <div class="main-contents__box__name--created_at">
@@ -31,9 +31,9 @@ $(function() {
               ${message.content}
             </p>
           </div>
-          </div>`
+        </div>`
       return html;
-    }
+    };
   }
   $('#new_message').on('submit', function(e) {
     e.preventDefault();
@@ -53,8 +53,30 @@ $(function() {
       $('.main-contents').animate({ scrollTop: $('.main-contents')[0].scrollHeight});
       $('form')[0].reset();
     })
-    .fail(function() {
-      alert('メッセージ送信に失敗しました');
-    });
   });
+  var reloadMessages = function() {
+    var last_message_id = $('.main-contents__box:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main-contents').append(insertHTML);
+        $('.main-contents').animate({ scrollTop: $('.main-contents')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-contents__box
+.main-contents__box{data: {message: {id: message.id}}}
   .main-contents__box__name
     = message.user.name
     .main-contents__box__name--created_at

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-
     namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
     namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
     end


### PR DESCRIPTION
#what
自分以外のユーザーが送信したメッセージも自動で追加表示されるようにした。

#why
今までの機能だと、送信者以外のユーザーはリロードしないと相手のメッセージは見れないようになっていて、不便であり、より使いやすい仕様にするため。